### PR TITLE
Use kelunik/highlight for syntax highlighting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ backend/mirror.jpg
 backend/mirror.jpg
 backend/GeoIP.dat
 .idea
+
+/vendor/

--- a/.htaccess
+++ b/.htaccess
@@ -2,3 +2,8 @@
   Order allow,deny
   Deny from all
 </FilesMatch>
+
+<Directory ~ "vendor">
+  Order allow,deny
+  Deny from all
+</Directory>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "php/web-php",
+    "description": "The www.php.net site.",
+    "type": "project",
+    "require": {
+        "kelunik/highlight": "^0.1.0"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,132 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "07e4eb4a459087c82857b3833d4fa985",
+    "packages": [
+        {
+            "name": "kelunik/highlight",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kelunik/php-highlight.git",
+                "reference": "c250388b4557df9ef06aec7d70cbae6ae99433e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kelunik/php-highlight/zipball/c250388b4557df9ef06aec7d70cbae6ae99433e5",
+                "reference": "c250388b4557df9ef06aec7d70cbae6ae99433e5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^2.1",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "macfja/phar-builder": "^0.2.5"
+            },
+            "type": "library",
+            "extra": {
+                "phar-builder": {
+                    "compression": "GZip",
+                    "name": "highlight.phar",
+                    "output-dir": "build",
+                    "include": [
+                        "info",
+                        "src"
+                    ],
+                    "entry-point": "bin/highlight",
+                    "events": {
+                        "command.package.start": [
+                            "mkdir -p info",
+                            "git describe --tags > info/build.version",
+                            "php -r 'echo time();' > info/build.time"
+                        ],
+                        "command.package.end": [
+                            "rm -rf info",
+                            "chmod +x build/highlight.phar"
+                        ]
+                    }
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Kelunik\\Highlight\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "PHP Syntax Highlighter",
+            "time": "2016-11-11T12:51:14+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4dd659edadffdc2143e4753df655d866dbfeedf0",
+                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "time": "2016-09-16T12:04:44+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/include/header.inc
+++ b/include/header.inc
@@ -3,8 +3,8 @@
 
 $css_files = array(
     '/styles/material.indigo-red.min.css',
-    '/styles/material.indigo-red.min.css',
     '/styles/theme.css',
+    '/styles/highlight.css',
 );
 
 if (isset($config['css'])) {
@@ -53,7 +53,7 @@ if (!isset($config["languages"])) {
 <head>
 
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>PHP: <?= $title ?></title>
 

--- a/include/layout.inc
+++ b/include/layout.inc
@@ -1,6 +1,12 @@
 <?php
 /* $Id$ */
 
+use Kelunik\Highlight\Highlighter;
+use Kelunik\Highlight\HtmlFormatter;
+use Kelunik\Highlight\PhpLexer;
+
+require_once __DIR__ . "/../vendor/autoload.php";
+
 $_SERVER['STATIC_ROOT'] = $MYSITE;
 $_SERVER['MYSITE'] = $MYSITE;
 
@@ -14,35 +20,13 @@ ini_set('highlight.html',    'html');
 // Highlight PHP code
 function highlight_php($code, $return = FALSE)
 {
-    $highlighted = highlight_string($code, TRUE);
+    static $highlighter = null;
 
-    // Use this ugly hack for now to avoid code snippets with bad syntax screwing up the highlighter
-    if(strstr($highlighted, "include/layout.inc</b>")) {
-	    $highlighted = '<span class="html">'. nl2br(htmlentities($code, ENT_HTML5), FALSE) ."</span>";
-	}
+    if ($highlighter === null) {
+        $highlighter = new Highlighter(new HtmlFormatter("php"), new PhpLexer);
+    }
 
-    // Fix output to use CSS classes and wrap well
-    $highlighted = '<div class="phpcode">' . str_replace(
-        array(
-            '&nbsp;',
-            '<br>',
-            '<span style="color: ',
-            '</font>',
-            "\n ",
-            '  ',
-            '  '
-        ),
-        array(
-            ' ',
-            "<br>\n",
-            '<span class="',
-            '</span>',
-            "\n&nbsp;",
-            '&nbsp; ',
-            '&nbsp; '
-        ),
-        $highlighted
-    ) . '</div>';
+    $highlighted = $highlighter->highlight($code);
 
     if ($return) { return $highlighted; }
     else { echo $highlighted; }
@@ -229,7 +213,7 @@ function download_link($file, $title, $showsize = TRUE, $mirror = '')
             }
             echo ']';
         }
-        
+
     }
 }
 

--- a/releases/5_3_3.php
+++ b/releases/5_3_3.php
@@ -8,7 +8,7 @@ site_header("PHP 5.3.3 Release Announcement");
 <h1>PHP 5.3.3 Release Announcement</h1>
 <p>
 The PHP development team would like to announce the immediate
-availability of PHP 5.3.3. This release focuses on improving the  
+availability of PHP 5.3.3. This release focuses on improving the
 stability and security of the PHP 5.3.x branch with over 100 bug
 fixes, some of which are security related. All users are encouraged
 to upgrade to this release.
@@ -23,7 +23,7 @@ to upgrade to this release.
 	non-namespaced classes.
 
 	<p><?php
-	highlight_string('<?php
+	highlight_php('<?php
 namespace Foo;
 class Bar {
     public function Bar() {

--- a/styles/highlight.css
+++ b/styles/highlight.css
@@ -1,0 +1,28 @@
+.php-variable {
+    color: blue;
+}
+
+.php-string,
+.php-doc-comment {
+    color: green;
+    font-style: italic;
+}
+
+.php-comment {
+    color: grey;
+    font-style: italic;
+}
+
+.php-open-close {
+    color: grey;
+    font-weight: bold;
+}
+
+.php-keyword,
+.php-control {
+    color: purple;
+}
+
+.php-number {
+    color: red;
+}


### PR DESCRIPTION
Relates to #2. Doesn't highlight manual pages yet, just user notes and custom snippets.